### PR TITLE
[17.06] Fix systemd cgroup after memory type changed

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -260,7 +260,7 @@ func (m *Manager) Apply(pid int) error {
 
 	if c.Resources.Memory != 0 {
 		properties = append(properties,
-			newProp("MemoryLimit", c.Resources.Memory))
+			newProp("MemoryLimit", uint64(c.Resources.Memory)))
 	}
 
 	if c.Resources.CpuShares != 0 {


### PR DESCRIPTION
backport of https://github.com/opencontainers/runc/pull/1573

I'm not quite sure about the root cause, looks like
systemd still want them to be uint64.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>
(cherry picked from commit acaf6897f566c2f592a488c83dafcddec41524be)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>