### PR TITLE
[17.06 backport] libcontainer: ability to compile without kmem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 RUNC_IMAGE := runc_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 PROJECT := github.com/opencontainers/runc
-BUILDTAGS := seccomp
+BUILDTAGS ?= seccomp
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 

--- a/libcontainer/cgroups/fs/kmem.go
+++ b/libcontainer/cgroups/fs/kmem.go
@@ -1,0 +1,54 @@
+// +build linux,!nokmem
+
+package fs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall" // for Errno type only
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+const cgroupKernelMemoryLimit = "memory.kmem.limit_in_bytes"
+
+func EnableKernelMemoryAccounting(path string) error {
+	// Check if kernel memory is enabled
+	// We have to limit the kernel memory here as it won't be accounted at all
+	// until a limit is set on the cgroup and limit cannot be set once the
+	// cgroup has children, or if there are already tasks in the cgroup.
+	for _, i := range []int64{1, -1} {
+		if err := setKernelMemory(path, i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setKernelMemory(path string, kernelMemoryLimit int64) error {
+	if path == "" {
+		return fmt.Errorf("no such directory for %s", cgroupKernelMemoryLimit)
+	}
+	if !cgroups.PathExists(filepath.Join(path, cgroupKernelMemoryLimit)) {
+		// kernel memory is not enabled on the system so we should do nothing
+		return nil
+	}
+	if err := ioutil.WriteFile(filepath.Join(path, cgroupKernelMemoryLimit), []byte(strconv.FormatInt(kernelMemoryLimit, 10)), 0700); err != nil {
+		// Check if the error number returned by the syscall is "EBUSY"
+		// The EBUSY signal is returned on attempts to write to the
+		// memory.kmem.limit_in_bytes file if the cgroup has children or
+		// once tasks have been attached to the cgroup
+		if pathErr, ok := err.(*os.PathError); ok {
+			if errNo, ok := pathErr.Err.(syscall.Errno); ok {
+				if errNo == syscall.EBUSY {
+					return fmt.Errorf("failed to set %s, because either tasks have already joined this cgroup or it has children", cgroupKernelMemoryLimit)
+				}
+			}
+		}
+		return fmt.Errorf("failed to write %v to %v: %v", kernelMemoryLimit, cgroupKernelMemoryLimit, err)
+	}
+	return nil
+}

--- a/libcontainer/cgroups/fs/kmem_disabled.go
+++ b/libcontainer/cgroups/fs/kmem_disabled.go
@@ -1,0 +1,11 @@
+// +build linux,nokmem
+
+package fs
+
+func EnableKernelMemoryAccounting(path string) error {
+	return nil
+}
+
+func setKernelMemory(path string, kernelMemoryLimit int64) error {
+	return nil
+}

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -5,21 +5,18 @@ package fs
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 const (
-	cgroupKernelMemoryLimit = "memory.kmem.limit_in_bytes"
-	cgroupMemorySwapLimit   = "memory.memsw.limit_in_bytes"
-	cgroupMemoryLimit       = "memory.limit_in_bytes"
+	cgroupMemorySwapLimit = "memory.memsw.limit_in_bytes"
+	cgroupMemoryLimit     = "memory.limit_in_bytes"
 )
 
 type MemoryGroup struct {
@@ -61,44 +58,6 @@ func (s *MemoryGroup) Apply(d *cgroupData) (err error) {
 	_, err = d.join("memory")
 	if err != nil && !cgroups.IsNotFound(err) {
 		return err
-	}
-	return nil
-}
-
-func EnableKernelMemoryAccounting(path string) error {
-	// Check if kernel memory is enabled
-	// We have to limit the kernel memory here as it won't be accounted at all
-	// until a limit is set on the cgroup and limit cannot be set once the
-	// cgroup has children, or if there are already tasks in the cgroup.
-	for _, i := range []int64{1, -1} {
-		if err := setKernelMemory(path, i); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func setKernelMemory(path string, kernelMemoryLimit int64) error {
-	if path == "" {
-		return fmt.Errorf("no such directory for %s", cgroupKernelMemoryLimit)
-	}
-	if !cgroups.PathExists(filepath.Join(path, cgroupKernelMemoryLimit)) {
-		// kernel memory is not enabled on the system so we should do nothing
-		return nil
-	}
-	if err := ioutil.WriteFile(filepath.Join(path, cgroupKernelMemoryLimit), []byte(strconv.FormatInt(kernelMemoryLimit, 10)), 0700); err != nil {
-		// Check if the error number returned by the syscall is "EBUSY"
-		// The EBUSY signal is returned on attempts to write to the
-		// memory.kmem.limit_in_bytes file if the cgroup has children or
-		// once tasks have been attached to the cgroup
-		if pathErr, ok := err.(*os.PathError); ok {
-			if errNo, ok := pathErr.Err.(syscall.Errno); ok {
-				if errNo == syscall.EBUSY {
-					return fmt.Errorf("failed to set %s, because either tasks have already joined this cgroup or it has children", cgroupKernelMemoryLimit)
-				}
-			}
-		}
-		return fmt.Errorf("failed to write %v to %v: %v", kernelMemoryLimit, cgroupKernelMemoryLimit, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Backport of https://github.com/opencontainers/runc/pull/1921 for 17.06


There was a conflict because https://github.com/opencontainers/runc/pull/1442 is not in the 17.06 branch

I resolved the conflict by;

- Cleaning up the conflicts in the "import"
- Using `EnableKernelMemoryAccounting` and `setKernelMemory` from the 17.06 branch, and copying those to `kmem.go`;

```patch
diff --git a/libcontainer/cgroups/fs/kmem.go b/libcontainer/cgroups/fs/kmem.go
index 8df73777..4d10ace2 100644
--- a/libcontainer/cgroups/fs/kmem.go
+++ b/libcontainer/cgroups/fs/kmem.go
@@ -11,7 +11,6 @@ import (
        "syscall" // for Errno type only
 
        "github.com/opencontainers/runc/libcontainer/cgroups"
-       "golang.org/x/sys/unix"
 )
 
 const cgroupKernelMemoryLimit = "memory.kmem.limit_in_bytes"
@@ -44,7 +43,7 @@ func setKernelMemory(path string, kernelMemoryLimit int64) error {
                // once tasks have been attached to the cgroup
                if pathErr, ok := err.(*os.PathError); ok {
                        if errNo, ok := pathErr.Err.(syscall.Errno); ok {
-                               if errNo == unix.EBUSY {
+                               if errNo == syscall.EBUSY {
                                        return fmt.Errorf("failed to set %s, because either tasks have already joined this cgroup or it has children", cgroupKernelMemoryLimit)
                                }
                        }
```

The conflict before resolution is below:

<details>

```patch
diff --cc libcontainer/cgroups/fs/memory.go
index 68f40a9b,d5310d56..00000000
--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@@ -10,7 -9,6 +9,10 @@@ import 
        "path/filepath"
        "strconv"
        "strings"
++<<<<<<< HEAD
 +      "syscall"
++=======
++>>>>>>> 6a2c1559... libcontainer: ability to compile without kmem
  
        "github.com/opencontainers/runc/libcontainer/cgroups"
        "github.com/opencontainers/runc/libcontainer/configs"
@@@ -65,44 -62,6 +66,47 @@@ func (s *MemoryGroup) Apply(d *cgroupDa
        return nil
  }
  
++<<<<<<< HEAD
 +func EnableKernelMemoryAccounting(path string) error {
 +      // Check if kernel memory is enabled
 +      // We have to limit the kernel memory here as it won't be accounted at all
 +      // until a limit is set on the cgroup and limit cannot be set once the
 +      // cgroup has children, or if there are already tasks in the cgroup.
 +      for _, i := range []int64{1, -1} {
 +              if err := setKernelMemory(path, i); err != nil {
 +                      return err
 +              }
 +      }
 +      return nil
 +}
 +
 +func setKernelMemory(path string, kernelMemoryLimit int64) error {
 +      if path == "" {
 +              return fmt.Errorf("no such directory for %s", cgroupKernelMemoryLimit)
 +      }
 +      if !cgroups.PathExists(filepath.Join(path, cgroupKernelMemoryLimit)) {
 +              // kernel memory is not enabled on the system so we should do nothing
 +              return nil
 +      }
 +      if err := ioutil.WriteFile(filepath.Join(path, cgroupKernelMemoryLimit), []byte(strconv.FormatInt(kernelMemoryLimit, 10)), 0700); err != nil {
 +              // Check if the error number returned by the syscall is "EBUSY"
 +              // The EBUSY signal is returned on attempts to write to the
 +              // memory.kmem.limit_in_bytes file if the cgroup has children or
 +              // once tasks have been attached to the cgroup
 +              if pathErr, ok := err.(*os.PathError); ok {
 +                      if errNo, ok := pathErr.Err.(syscall.Errno); ok {
 +                              if errNo == syscall.EBUSY {
 +                                      return fmt.Errorf("failed to set %s, because either tasks have already joined this cgroup or it has children", cgroupKernelMemoryLimit)
 +                              }
 +                      }
 +              }
 +              return fmt.Errorf("failed to write %v to %v: %v", kernelMemoryLimit, cgroupKernelMemoryLimit, err)
 +      }
 +      return nil
 +}
 +
++=======
++>>>>>>> 6a2c1559... libcontainer: ability to compile without kmem
  func setMemoryAndSwap(path string, cgroup *configs.Cgroup) error {
        // If the memory update is set to -1 we should also
        // set swap to -1, it means unlimited memory.
```

</details>




Commit https://github.com/opencontainers/runc/commit/fe898e7862f945fa3632580139602c627dcb9be0 (PR https://github.com/opencontainers/runc/pull/1350) enables kernel memory accounting
for all cgroups created by libcontainer -- even if kmem limit is
not configured.

Kernel memory accounting is known to be broken in some kernels,
specifically the ones from RHEL7 (including RHEL 7.5). Those
kernels do not support kernel memory reclaim, and are prone to
oopses. Unconditionally enabling kmem acct on such kernels lead
to bugs, such as

* https://github.com/opencontainers/runc/issues/1725
* https://github.com/kubernetes/kubernetes/issues/61937
* https://github.com/moby/moby/issues/29638

This commit gives a way to compile runc without kernel memory setting
support. To do so, use something like

	make BUILDTAGS="seccomp nokmem"
