### PR TITLE
[17.06 backport] rootfs: umount all procfs and sysfs with --no-pivot

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -707,9 +707,48 @@ func pivotRoot(rootfs string) error {
 }
 
 func msMoveRoot(rootfs string) error {
+	mountinfos, err := mount.GetMounts()
+	if err != nil {
+		return err
+	}
+
+	absRootfs, err := filepath.Abs(rootfs)
+	if err != nil {
+		return err
+	}
+
+	for _, info := range mountinfos {
+		p, err := filepath.Abs(info.Mountpoint)
+		if err != nil {
+			return err
+		}
+		// Umount every syfs and proc file systems, except those under the container rootfs
+		if (info.Fstype != "proc" && info.Fstype != "sysfs") || filepath.HasPrefix(p, absRootfs) {
+			continue
+		}
+		// Be sure umount events are not propagated to the host.
+		if err := syscall.Mount("", p, "", syscall.MS_SLAVE|syscall.MS_REC, ""); err != nil {
+			return err
+		}
+		if err := syscall.Unmount(p, syscall.MNT_DETACH); err != nil {
+			if err != syscall.EINVAL && err != syscall.EPERM {
+				return err
+			} else {
+				// If we have not privileges for umounting (e.g. rootless), then
+				// cover the path.
+				if err := syscall.Mount("tmpfs", p, "tmpfs", 0, ""); err != nil {
+					return err
+				}
+			}
+		}
+	}
 	if err := syscall.Mount(rootfs, "/", "", syscall.MS_MOVE, ""); err != nil {
 		return err
 	}
+	return chroot(rootfs)
+}
+
+func chroot(rootfs string) error {
 	if err := syscall.Chroot("."); err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport of https://github.com/opencontainers/runc/pull/1962 for 17.06

cherry-pick was not clean, due to upstream having switched from `syscall` to `unix`. I resolved this by `s/unix/syscall/`.

------------------------------------------


When creating a new user namespace, the kernel doesn't allow to mount
a new procfs or sysfs file system if there is not already one instance
fully visible in the current mount namespace.

When using --no-pivot we were effectively inhibiting this protection
from the kernel, as /proc and /sys from the host are still present in
the container mount namespace.

A container without full access to /proc could then create a new user
namespace, and from there able to mount a fully visible /proc, bypassing
the limitations in the container.

A simple reproducer for this issue is:

unshare -mrfp sh -c "mount -t proc none /proc && echo c > /proc/sysrq-trigger"

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 28a697cce3e4f905dca700eda81d681a30eef9cd)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>