### PR TITLE
[17.06 backport] Update libseccomp-golang dependency for filter generation bugfix [ENGCORE-866]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ env:
     - BUILDTAGS="seccomp apparmor selinux ambient"
 
 before_install:
+  - echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get -qq update
-  - sudo apt-get install -y libseccomp-dev libapparmor-dev
+  - sudo apt-get install -y libapparmor-dev libseccomp-dev/trusty-backports
   - env | grep TRAVIS_
 
 script:

--- a/vendor.conf
+++ b/vendor.conf
@@ -5,7 +5,7 @@ github.com/opencontainers/runtime-spec a45ba0989fc26c695fe166a49c45bb8b7618ab36 
 # Core libcontainer functionality.
 github.com/mrunalp/fileutils ed869b029674c0e9ce4c0dfa781405c2d9946d08
 github.com/opencontainers/selinux v1.0.0-rc1
-github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
+github.com/seccomp/libseccomp-golang 84e90a91acea0f4e51e62bc1a75de18b1fc0790f
 github.com/Sirupsen/logrus 26709e2714106fb8ad40b773b711ebce25b78914
 github.com/syndtr/gocapability e7cb7fa329f456b3855136a2642b197bad7366ba
 github.com/vishvananda/netlink 1e2e08e8a2dcdacaae3f14ac44c5cfa31361f270

--- a/vendor/github.com/seccomp/libseccomp-golang/README
+++ b/vendor/github.com/seccomp/libseccomp-golang/README
@@ -24,3 +24,28 @@ please note that a Google account is not required to subscribe to the mailing
 list.
 
 	-> https://groups.google.com/d/forum/libseccomp
+
+Documentation is also available at:
+
+	-> https://godoc.org/github.com/seccomp/libseccomp-golang
+
+* Installing the package
+
+The libseccomp-golang bindings require at least Go v1.2.1 and GCC v4.8.4;
+earlier versions may yield unpredictable results.  If you meet these
+requirements you can install this package using the command below:
+
+	$ go get github.com/seccomp/libseccomp-golang
+
+* Testing the Library
+
+A number of tests and lint related recipes are provided in the Makefile, if
+you want to run the standard regression tests, you can excute the following:
+
+	$ make check
+
+In order to execute the 'make lint' recipe the 'golint' tool is needed, it
+can be found at:
+
+	-> https://github.com/golang/lint
+


### PR DESCRIPTION
addresses [ENGCORE-866]
backport of https://github.com/opencontainers/runc/pull/1424 for 17.06

A bug in Seccomp filter handling was recently identified in Moby related to handling of syscall arguments in Seccomp filters (moby/moby#32714). The bug was in the libseccomp-golang bindings, and has been fixed there. This PR updates the bindings to include this fix, and provides integration tests to catch regressions in this behavior.

The minimum supported version of libseccomp is bumped from v2.1.0 to v2.2.0 by associated changes to the bindings. Support for v2.1.0 was never very good (some features had to be gated off because of a library bug), though it is still the version provided by a few major distributions. If this change is contentious, I can see about backing out the changes that require v2.2.0.


This fixes [CVE-2017-18367](https://nvd.nist.gov/vuln/detail/CVE-2017-18367) - Multiple syscall arguments were incorrectly combined with logical-OR, instead of logical-AND 

[ENGCORE-866]: https://docker.atlassian.net/browse/ENGCORE-866